### PR TITLE
change format of grants header

### DIFF
--- a/lib/ti_rails_auth/grants_header_authenticable.rb
+++ b/lib/ti_rails_auth/grants_header_authenticable.rb
@@ -41,7 +41,10 @@ module TiRailsAuth
     def grants!
       self.grants ||= if grants_header
                         begin
-                          ActiveSupport::JSON.decode Base64.decode64(grants_header)
+                          header = ActiveSupport::JSON.decode Base64.decode64(grants_header)
+                          if header && header['grants'] && header['grants'].first && header['grants'].first.is_a?(Hash)
+                            header['grants'].first
+                          end
                         rescue ActiveSupport::JSON.parse_error
                           nil
                         end

--- a/spec/lib/ti_rails_auth/grants_header_authenticable_spec.rb
+++ b/spec/lib/ti_rails_auth/grants_header_authenticable_spec.rb
@@ -27,8 +27,10 @@ describe TiRailsAuth::GrantsHeaderAuthenticable do
     let!(:headers) do
       { 'HTTP_FROM' => 'jon.snow@ti.com',
         'HTTP_X_GRANTS' => Base64.encode64(ActiveSupport::JSON.encode({
-          'controls'      => { 'knows' => 'nothing' },
-          'preferences' => { 'wear' => 'black' }
+          'grants' => [{
+            'controls'      => { 'knows' => 'nothing' },
+            'preferences' => { 'wear' => 'black' }
+          }]
         })) }
     end
 


### PR DESCRIPTION
Reads X_GRANTS headers under the format:
{'grants' => [{
                  'controls' => [...],
                  'preferences' => [...]
                }]
}

Instead of 
{
     'controls' => [...],
     'preferences' => [...]
}
